### PR TITLE
Adjust secure test to boolean.

### DIFF
--- a/modoboa_imap_migration/templates/modoboa_imap_migration/offlineimap.conf
+++ b/modoboa_imap_migration/templates/modoboa_imap_migration/offlineimap.conf
@@ -19,7 +19,7 @@ remotepasseval = get_user_password("{{ migration }}")
 type = IMAP
 remotehost = {{ imap_server_address }}
 remoteport = {{ imap_server_port }}
-{% if imap_server_secured == "yes" %}
+{% if imap_server_secured %}
 ssl = yes
 sslcacertfile = /etc/ssl/certs/ca-certificates.crt
 {% else %}


### PR DESCRIPTION
Value passed to the template is a boolean value, not a string.

This  fixes #19