### PR TITLE
Removed status_backend

### DIFF
--- a/modoboa_imap_migration/templates/modoboa_imap_migration/offlineimap.conf
+++ b/modoboa_imap_migration/templates/modoboa_imap_migration/offlineimap.conf
@@ -6,7 +6,6 @@ pythonfile = ~/.offlineimap.py
 [Account {{ migration }}]
 localrepository = Local_{{ migration }}
 remoterepository = Remote_{{ migration }}
-status_backend = sqlite
 
 [Repository Local_{{ migration }}]
 type = IMAP


### PR DESCRIPTION
Offlineimap defaults to sqlite as of 7.1.0 option no longer required

As per #16