### PR TITLE
prepare for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
   - pip install -e git+https://github.com/modoboa/modoboa.git#egg=modoboa
 
 install:
-  - pip install -q -r requirements.txt
-  - pip install -q -r test-requirements.txt
-  - python setup.py -q develop
+  - pip install -r requirements.txt
+  - pip install -r test-requirements.txt
+  - python setup.py develop
 
 script:
   - cd test_project

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,26 +16,18 @@ sudo: false
 
 cache: pip
 
-services:
-  - postgres
-  - mysql
+addons:
+  postgresql: "9.3"
+  mysql: "5.5"
 
 before_install:
   - pip install codecov
-  - if [[ $DB = "POSTGRESQL" ]]; then pip install -q psycopg2; fi
-  - if [[ $DB = "MYSQL" ]]; then pip install -q mysqlclient; fi
-  - pip install -e git+https://github.com/modoboa/modoboa#egg=modoboa
+  - pip install -e git+https://github.com/modoboa/modoboa.git#egg=modoboa
 
 install:
   - pip install -q -r requirements.txt
   - pip install -q -r test-requirements.txt
   - python setup.py -q develop
-
-before_script:
-  - if [[ $DB = "POSTGRESQL" ]]; then psql -c "CREATE DATABASE modoboa_test;" -U postgres; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "CREATE DATABASE IF NOT EXISTS modoboa_test;" -uroot; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "CREATE USER 'modoboa'@'localhost' IDENTIFIED BY 'modoboa'" -uroot; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'modoboa'@'localhost';" -uroot; fi
 
 script:
   - cd test_project
@@ -54,8 +46,9 @@ deploy:
   user: tonio
   password:
     secure: vDpojbQnBdmXXfzJdwWhLbVHyFXpSC0glYNk42rbfzdwQnAA9rbXxzX683OcBZPhqozHwCkazOQmDzzBU/Vue4hgAz5U5rLemMQp288urVUQrt2IPwfWyXe+Cgu9CebiwhWDh4tgWBiFvNySmpuP0xJRVi0oKkWoEM+dcfsTa7OSuCx/e8eRA35fWIo7/xyxc1Gl1sdg0J+TwQJV6EyUxvhTzqP0PoZSGLkOHE+SOZJyM8UAo48VV5+uFqKVae33tsIhJBJu6/LvWFFu0Yedr/DqjZ8OY5tTU86Bn+MblBM8LmKpKI1XNxgULL7+GXS1c1YIo5Wbw8esEHJq5ro7eqXe/KnDar8l4/+MPExlQsmjkOxwvWAF45VMfFm5oVXZYsD8giD+a6EFT6ELDOKb973fDLKZLmNToZRNWkbBDTrcd/ppElswTORMkHhew/W7UuXtEQxNKWcUETuuViyPNMFrTy3SZ8oIuG2hqbx3wIrj34PlxSJGHSRlE7aLwG5whnkgkEFN9bfvfqpsowrHnqbBfgUJt07uV0bKEjwqEz55PALRhDjRoGkvtDkPJjnJvwY+ieC2VKyLNzZBi2iw/Mh6peyK0oTgCzdpUvSLRuiNzpWf+jpGE0aOWxcwcdEA6a4aTJXivMgg5/4Jbvs+NbjNgTfXdOApMWkxu2aCNWI=
-  server: https://upload.pypi.org/legacy/
   skip_cleanup: true
+  distributions: "sdist bdist_wheel"
   on:
     tags: true
-    python: '3.6'
+    python: "3.6"
+    condition: $DB = POSTGRESQL

--- a/modoboa_imap_migration/__init__.py
+++ b/modoboa_imap_migration/__init__.py
@@ -1,3 +1,16 @@
-__version__ = "1.1.2"
+# -*- coding: utf-8 -*-
+
+"""A plugin to migrate mailboxes using IMAP."""
+
+from __future__ import unicode_literals
+
+from pkg_resources import get_distribution, DistributionNotFound
+
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass
 
 default_app_config = "modoboa_imap_migration.apps.IMAPMigrationConfig"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-modoboa>=1.7.0
+modoboa>=1.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,79 +1,71 @@
 #!/usr/bin/env python
-# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# -*- coding: utf-8 -*-
 
-import os
-import re
+"""
+A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+"""
+
+from __future__ import unicode_literals
+
+import io
+from os import path
+from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
-from modoboa_imap_migration import __version__
 
-ROOT = os.path.dirname(__file__)
-PIP_REQUIRES = os.path.join(ROOT, "requirements.txt")
-
-
-def parse_requirements(*filenames):
-    """
-    We generate our install_requires from the pip-requires and test-requires
-    files so that we don't have to maintain the dependency definitions in
-    two places.
-    """
+def get_requirements(requirements_file):
+    """Use pip to parse requirements file."""
     requirements = []
-    for f in filenames:
-        for line in open(f, 'r').read().split('\n'):
-            # Comment lines. Skip.
-            if re.match(r'(\s*#)|(\s*$)', line):
-                continue
-            # Editable matches. Put the egg name into our reqs list.
-            if re.match(r'\s*-e\s+', line):
-                pkg = re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1', line)
-                requirements.append("%s" % pkg)
-            # File-based installs not supported/needed. Skip.
-            elif re.match(r'\s*-f\s+', line):
-                pass
-            else:
-                requirements.append(line)
+    if path.isfile(requirements_file):
+        for req in parse_requirements(requirements_file, session="hack"):
+            # check markers, such as
+            #
+            #     rope_py3k    ; python_version >= '3.0'
+            #
+            if req.match_markers():
+                requirements.append(str(req.req))
     return requirements
 
 
-def parse_dependency_links(*filenames):
-    """
-    We generate our dependency_links from the pip-requires and test-requires
-    files for the dependencies pulled from github (prepended with -e).
-    """
-    dependency_links = []
-    for f in filenames:
-        for line in open(f, 'r').read().split('\n'):
-            if re.match(r'\s*-[ef]\s+', line):
-                line = re.sub(r'\s*-[ef]\s+', '', line)
-                line = re.sub(r'\s*git\+https', 'http', line)
-                line = re.sub(r'\.git#', '/tarball/master#', line)
-                dependency_links.append(line)
-    return dependency_links
+if __name__ == "__main__":
+    HERE = path.abspath(path.dirname(__file__))
+    INSTALL_REQUIRES = get_requirements(path.join(HERE, "requirements.txt"))
 
+    with io.open(path.join(HERE, "README.rst"), encoding="utf-8") as readme:
+        LONG_DESCRIPTION = readme.read()
 
-def read(fname):
-    return open(os.path.join(ROOT, fname)).read()
-
-
-setup(
-    name="modoboa-imap-migration",
-    version=__version__,
-    url='http://modoboa.org/',
-    license='MIT',
-    description="A plugin to migrate mailboxes using IMAP",
-    long_description=read('README.rst'),
-    author='Antoine Nguyen',
-    author_email='tonio@ngyn.org',
-    packages=find_packages(),
-    include_package_data=True,
-    zip_safe=False,
-    install_requires=parse_requirements(PIP_REQUIRES),
-    dependency_links=parse_dependency_links(PIP_REQUIRES),
-    classifiers=['Development Status :: 5 - Production/Stable',
-                 'Framework :: Django',
-                 'Intended Audience :: System Administrators',
-                 'License :: OSI Approved :: MIT License',
-                 'Operating System :: OS Independent',
-                 'Programming Language :: Python',
-                 'Topic :: Internet :: WWW/HTTP']
-)
+    setup(
+        name="modoboa-imap-migration",
+        description="A plugin to migrate mailboxes using IMAP",
+        long_description=LONG_DESCRIPTION,
+        license="MIT",
+        url="http://modoboa.org/",
+        author="Antoine Nguyen",
+        author_email="tonio@ngyn.org",
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "Environment :: Web Environment",
+            "Framework :: Django :: 1.11",
+            "Intended Audience :: System Administrators",
+            "License :: OSI Approved :: MIT License",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python :: 2",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.4",
+            "Programming Language :: Python :: 3.5",
+            "Programming Language :: Python :: 3.6",
+            "Topic :: Communications :: Email",
+            "Topic :: Internet :: WWW/HTTP",
+        ],
+        keywords="email",
+        packages=find_packages(exclude=["test_project"]),
+        include_package_data=True,
+        zip_safe=False,
+        install_requires=INSTALL_REQUIRES,
+        use_scm_version=True,
+        setup_requires=["setuptools_scm"],
+    )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,4 @@
 factory-boy>=2.4
 testfixtures==4.7.0
+psycopg2>=2.5.4
+mysqlclient>=1.3.3


### PR DESCRIPTION
Builds will currently fail until Modoboa 1.10.0 is tagged, [this build](https://travis-ci.org/fyfe/modoboa-imap-migration/builds/332954611) shows the other changes don't break anything. 



- refactor setup.py
    - use setuptools_scm to generate version number, normal releases will use the tagged version (ie 1.9.1), versions installed from source will append the git commit number to the version number (ie 1.9.1.dev61+g4584c93)

    - use io.open() to read text files to correctly handle utf-8 characters

    - use pip to parse requirements.txt

    - update classifiers to specify python and django versions supported

    - wheel distributions can now be built using `python setup.py bdist_wheel`
- fix travis setup
    - target oldest currently supported database servers, travis currently defaults to PostgreSQL 9.2 which isn't supported anymore.

    - move database dependencies out of travis.yml into test_requirements.txt and pin to minimum versions recommended by django.
      See https://docs.djangoproject.com/en/1.11/ref/databases/

    - remove unnecessary database setup.
      See modoboa/modoboa#1340

    - create binary wheels when a tag is pushed